### PR TITLE
Touchup the `iframe` element of DataLad-Registry talk

### DIFF
--- a/content/pages/projects.html
+++ b/content/pages/projects.html
@@ -117,8 +117,8 @@
           <iframe width="560" height="315"
                   src="https://www.youtube.com/embed/_McJ1BtLsiQ?si=OTtLO8QFwzEL1Qiv"
                   title="YouTube video player" frameborder="0"
-                  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-                  referrerpolicy="strict-origin-when-cross-origin" allowfullscreen=true></iframe>
+                  allow="accelerometer; autoplay; clipboard-write; encrypted-media; fullscreen; gyroscope; picture-in-picture; web-share"
+                  referrerpolicy="strict-origin-when-cross-origin"></iframe>
         </details>
       </li>
     </ul>

--- a/content/pages/projects.html
+++ b/content/pages/projects.html
@@ -116,9 +116,10 @@
 
           <iframe width="560" height="315"
                   src="https://www.youtube.com/embed/_McJ1BtLsiQ?si=OTtLO8QFwzEL1Qiv"
-                  title="YouTube video player" frameborder="0"
+                  title="YouTube video player"
                   allow="accelerometer; autoplay; clipboard-write; encrypted-media; fullscreen; gyroscope; picture-in-picture; web-share"
-                  referrerpolicy="strict-origin-when-cross-origin"></iframe>
+                  referrerpolicy="strict-origin-when-cross-origin"
+                  style="border-width: 0"></iframe>
         </details>
       </li>
     </ul>

--- a/content/pages/projects.html
+++ b/content/pages/projects.html
@@ -108,7 +108,7 @@
       searches, accessible through both a web interface and a RESTful API.
     </p>
     <ul>
-      <li>
+      <li style="cursor: pointer">
         <details>
           <summary>
             Talk at distribits 2024: Bringing Benefits of Centrality to Datalad


### PR DESCRIPTION
This PR updates the `iframe` element of the DataLad-Registry talk with up-to-date HTML and sets the cursor for the element to `pointer`, so to signal the element is interactive/expandable (this is especially needed in Chrome).