### PR TITLE
Replace Task force site with INCF main page

### DIFF
--- a/content/pages/whoweare.html
+++ b/content/pages/whoweare.html
@@ -670,8 +670,8 @@
 	  <div id="people">
 		<h2>Partners</h2>
 		<div class="row">
-		  <!-- <h3>INCF Neuroimaging Task Force</h3> -->
-		  <a href="http://wiki.incf.org/mediawiki/index.php/Neuroimaging_Task_Force"><img src="/theme/img/3rd/incf_logo.png" style="width:400px"/></a>
+		  <!-- <h3>INCF</h3> -->
+		  <a href="https://incf.org"><img src="/theme/img/3rd/incf_logo.png" style="width:400px"/></a>
 
 		  <!-- <h3>NITRC</h3> -->
 		  <a href="http://nitrc.org"><img src="/theme/img/3rd/nitrc_logo.png" alt="Neuroimaging tools and resources clearinghouse" style="width:400px"/></a>


### PR DESCRIPTION
I did find a neuroimaging task force, but it didn't seem related to incf. Given that the logo is just the incf logo, I thought it might be best to just go with the root site.